### PR TITLE
Add dynamic text support to Text and LongText tricks

### DIFF
--- a/beagle-core/src/main/java/com/pandulapeter/beagleCore/configuration/Trick.kt
+++ b/beagle-core/src/main/java/com/pandulapeter/beagleCore/configuration/Trick.kt
@@ -54,11 +54,13 @@ sealed class Trick {
      *
      * @param id - A unique ID for the module. If you don't intend to dynamically remove / modify the module, a suitable default value is auto-generated.
      * @param text - The text that should be displayed.
+     * @param dynamicText - A lambda that provides the text to display. If provided, it will override [text].
      * @param isTitle - Whether or not the text should appear in bold style. False by default.
      */
     data class Text(
         override val id: String = UUID.randomUUID().toString(),
-        val text: CharSequence,
+        val text: CharSequence = "",
+        val dynamicText: (() -> String)? = null,
         val isTitle: Boolean = false
     ) : Trick()
 
@@ -69,12 +71,14 @@ sealed class Trick {
      * @param id - A unique ID for the module. If you don't intend to dynamically remove / modify the module, a suitable default value is auto-generated.
      * @param title - The title of the module.
      * @param text - The text that should be displayed.
+     * @param dynamicText - A lambda that provides the text to display. If provided, it will override [text].
      * @param isInitiallyExpanded - Whether or not the list should be expanded when the drawer is opened for the first time. False by default.
      */
     data class LongText(
         override val id: String = UUID.randomUUID().toString(),
         override val title: CharSequence,
-        val text: CharSequence,
+        val text: CharSequence = "",
+        val dynamicText: (() -> String)? = null,
         override val isInitiallyExpanded: Boolean = false
     ) : Trick(), Expandable {
 

--- a/beagle/src/main/java/com/pandulapeter/beagle/Beagle.kt
+++ b/beagle/src/main/java/com/pandulapeter/beagle/Beagle.kt
@@ -122,6 +122,7 @@ object Beagle : BeagleContract {
     override fun fetch(activity: Activity) {
         if (isEnabled) {
             drawers[activity]?.run { (parent as? BeagleDrawerLayout?)?.openDrawer(this) }
+            updateItems()
         }
     }
 

--- a/beagle/src/main/java/com/pandulapeter/beagle/utils/Extensions.kt
+++ b/beagle/src/main/java/com/pandulapeter/beagle/utils/Extensions.kt
@@ -128,7 +128,7 @@ internal fun List<Trick>.mapToViewModels(appearance: Appearance, networkLogItems
             is Trick.Text -> items.add(
                 TextViewModel(
                     id = trick.id,
-                    text = trick.text,
+                    text = trick.dynamicText?.invoke() ?: trick.text,
                     isTitle = trick.isTitle
                 )
             )
@@ -139,7 +139,7 @@ internal fun List<Trick>.mapToViewModels(appearance: Appearance, networkLogItems
                     listOf(
                         LongTextViewModel(
                             id = "longText_${trick.id}",
-                            text = trick.text
+                            text = trick.dynamicText?.invoke() ?: trick.text
                         )
                     )
                 }


### PR DESCRIPTION
Thank you for building this nice debug drawer @pandulapeter 🙌  I have tested some of the debug drawers available for Android and found this one visually appealing and very flexible to cover a lot of use-cases.

While implementing, I missed the option to show dynamic text content in the debug drawer as the Text and LongText tricks only take the text during the creation. So I added a minor update to those tricks to show dynamic text content. 

Please take a look and let me know your feedback.

**Change Summary:**
Text and LongText tricks take only static text param and show it for the whole lifetime of the debug drawer. Providing an option to add dynamic text to these tricks will cover more use-cases like app status updates, device locale, device timezone etc. New `dynamicText` param is provided with a default value and so it does not introduce any breaking changes.

**Note**
For this change to work, debug drawer items need to be updated whenever the drawer is open. It should not cause any performance issue as the debug drawer is already smart enough to calculate the diff to update only the necessary items whenever there is an update.