### PR TITLE
Refactor insets

### DIFF
--- a/internal-common/src/main/java/com/pandulapeter/beagle/common/configuration/Insets.kt
+++ b/internal-common/src/main/java/com/pandulapeter/beagle/common/configuration/Insets.kt
@@ -1,5 +1,7 @@
 package com.pandulapeter.beagle.common.configuration
 
+import androidx.core.view.WindowInsetsCompat
+
 /**
  * Data class representing system window insets.
  */
@@ -9,3 +11,14 @@ data class Insets(
     val right: Int = 0,
     val bottom: Int = 0
 )
+
+fun WindowInsetsCompat.getBeagleInsets(typeMask: Int): Insets =
+    getInsets(typeMask).mapToBeagleInsets()
+
+private fun androidx.core.graphics.Insets.mapToBeagleInsets(): Insets =
+    Insets(
+        left = left,
+        top = top,
+        right = right,
+        bottom = bottom
+    )

--- a/internal-core/src/main/java/com/pandulapeter/beagle/core/manager/listener/OverlayListenerManager.kt
+++ b/internal-core/src/main/java/com/pandulapeter/beagle/core/manager/listener/OverlayListenerManager.kt
@@ -2,26 +2,24 @@ package com.pandulapeter.beagle.core.manager.listener
 
 import android.graphics.Canvas
 import android.os.Build
+import androidx.core.view.WindowInsetsCompat
 import com.pandulapeter.beagle.BeagleCore
 import com.pandulapeter.beagle.common.configuration.Insets
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.common.listeners.OverlayListener
 
 internal class OverlayListenerManager : BaseListenerManager<OverlayListener>() {
 
     fun notifyListeners(canvas: Canvas) {
-        var leftInset = 0
-        var topInset = 0
-        var rightInset = 0
-        var bottomInset = 0
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            BeagleCore.implementation.currentActivity?.window?.decorView?.rootWindowInsets?.let {
-                leftInset = it.systemWindowInsetLeft
-                topInset = it.systemWindowInsetTop
-                rightInset = it.systemWindowInsetRight
-                bottomInset = it.systemWindowInsetBottom
-            }
+        val insets = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            BeagleCore.implementation.currentActivity?.window?.decorView?.let { view ->
+                view.rootWindowInsets?.let {
+                    WindowInsetsCompat.toWindowInsetsCompat(it, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                } ?: Insets()
+            } ?: Insets()
+        } else {
+            Insets()
         }
-        val insets = Insets(leftInset, topInset, rightInset, bottomInset)
         notifyListeners { it.onDrawOver(canvas, insets) }
     }
 

--- a/internal-core/src/main/java/com/pandulapeter/beagle/core/view/bugReport/BugReportActivity.kt
+++ b/internal-core/src/main/java/com/pandulapeter/beagle/core/view/bugReport/BugReportActivity.kt
@@ -8,10 +8,12 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewTreeObserver
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.pandulapeter.beagle.BeagleCore
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.common.configuration.toText
 import com.pandulapeter.beagle.core.R
 import com.pandulapeter.beagle.core.databinding.BeagleActivityBugReportBinding
@@ -99,11 +101,12 @@ class BugReportActivity : AppCompatActivity() {
             val contentPadding by lazy { dimension(R.dimen.beagle_content_padding) }
             binding.beagleBottomNavigationOverlay.setBackgroundColor(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) window.navigationBarColor else Color.BLACK)
             window.decorView.run {
-                setOnApplyWindowInsetsListener { _, insets ->
+                setOnApplyWindowInsetsListener { view, insets ->
                     onApplyWindowInsets(insets).also {
-                        binding.beagleToolbar.setPadding(it.systemWindowInsetLeft, 0, it.systemWindowInsetRight, 0)
-                        binding.beagleRecyclerView.setPadding(0, 0, 0, it.systemWindowInsetBottom + contentPadding)
-                        binding.beagleBottomNavigationOverlay.run { layoutParams = layoutParams.apply { height = it.systemWindowInsetBottom } }
+                        val beagleInsets = WindowInsetsCompat.toWindowInsetsCompat(it, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                        binding.beagleToolbar.setPadding(beagleInsets.left, 0, beagleInsets.right, 0)
+                        binding.beagleRecyclerView.setPadding(0, 0, 0, beagleInsets.bottom + contentPadding)
+                        binding.beagleBottomNavigationOverlay.run { layoutParams = layoutParams.apply { height = beagleInsets.bottom } }
                     }
                 }
                 requestApplyInsets()

--- a/internal-core/src/main/java/com/pandulapeter/beagle/core/view/gallery/GalleryActivity.kt
+++ b/internal-core/src/main/java/com/pandulapeter/beagle/core/view/gallery/GalleryActivity.kt
@@ -6,8 +6,10 @@ import android.os.Bundle
 import android.util.DisplayMetrics
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import com.pandulapeter.beagle.BeagleCore
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.core.R
 import com.pandulapeter.beagle.core.databinding.BeagleActivityGalleryBinding
 import com.pandulapeter.beagle.core.manager.ScreenCaptureManager
@@ -62,12 +64,13 @@ internal class GalleryActivity : AppCompatActivity(), DeleteConfirmationDialogFr
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
             binding.beagleBottomNavigationOverlay.setBackgroundColor(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) window.navigationBarColor else Color.BLACK)
             window.decorView.run {
-                setOnApplyWindowInsetsListener { _, insets ->
+                setOnApplyWindowInsetsListener { view, insets ->
                     onApplyWindowInsets(insets).also {
-                        binding.beagleToolbar.setPadding(it.systemWindowInsetLeft, 0, it.systemWindowInsetRight, 0)
-                        binding.beagleRecyclerView.setPadding(contentPadding, 0, contentPadding, it.systemWindowInsetBottom + contentPadding)
-                        binding.beagleBottomNavigationOverlay.run { layoutParams = layoutParams.apply { height = it.systemWindowInsetBottom } }
-                        binding.beagleTextView.setPadding(largePadding, largePadding, largePadding, largePadding + it.systemWindowInsetBottom)
+                        val beagleInsets = WindowInsetsCompat.toWindowInsetsCompat(it, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                        binding.beagleToolbar.setPadding(beagleInsets.left, 0, beagleInsets.right, 0)
+                        binding.beagleRecyclerView.setPadding(contentPadding, 0, contentPadding, beagleInsets.bottom + contentPadding)
+                        binding.beagleBottomNavigationOverlay.run { layoutParams = layoutParams.apply { height = beagleInsets.bottom } }
+                        binding.beagleTextView.setPadding(largePadding, largePadding, largePadding, largePadding + beagleInsets.bottom)
                     }
                 }
                 requestApplyInsets()

--- a/ui-activity/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuActivity.kt
+++ b/ui-activity/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuActivity.kt
@@ -6,9 +6,10 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.WindowInsetsCompat
 import com.pandulapeter.beagle.BeagleCore
 import com.pandulapeter.beagle.R
-import com.pandulapeter.beagle.common.configuration.Insets
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.core.view.InternalDebugMenuView
 import com.pandulapeter.beagle.utils.extensions.colorResource
 import com.pandulapeter.beagle.utils.extensions.tintedDrawable
@@ -34,20 +35,10 @@ internal class DebugMenuActivity : AppCompatActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
             bottomNavigationOverlay.setBackgroundColor(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) window.navigationBarColor else Color.BLACK)
             window.decorView.run {
-                setOnApplyWindowInsetsListener { _, insets ->
+                setOnApplyWindowInsetsListener { view, insets ->
                     onApplyWindowInsets(insets).also {
-                        val input = Insets(
-                            left = it.systemWindowInsetLeft,
-                            top = it.systemWindowInsetTop,
-                            right = it.systemWindowInsetRight,
-                            bottom = it.systemWindowInsetBottom
-                        )
-                        val output = BeagleCore.implementation.appearance.applyInsets?.invoke(input) ?: Insets(
-                            left = it.systemWindowInsetLeft,
-                            top = 0,
-                            right = it.systemWindowInsetRight,
-                            bottom = it.systemWindowInsetBottom
-                        )
+                        val input = WindowInsetsCompat.toWindowInsetsCompat(it, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                        val output = BeagleCore.implementation.appearance.applyInsets?.invoke(input) ?: input.copy(top = 0)
                         toolbar.setPadding(output.left, 0, output.right, 0)
                         debugMenu.applyInsets(0, 0, 0, output.bottom)
                         bottomNavigationOverlay.run { layoutParams = layoutParams.apply { height = output.bottom } }

--- a/ui-bottom-sheet/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuBottomSheet.kt
+++ b/ui-bottom-sheet/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuBottomSheet.kt
@@ -7,6 +7,7 @@ import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -63,7 +64,9 @@ internal class DebugMenuBottomSheet : BottomSheetDialogFragment(), UpdateListene
                 behavior = this
                 addBottomSheetCallback(bottomSheetCallback)
             }
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            dialog?.window?.let {
+                WindowCompat.setDecorFitsSystemWindows(it, false)
+            }
         }
     }
 

--- a/ui-bottom-sheet/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuBottomSheet.kt
+++ b/ui-bottom-sheet/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuBottomSheet.kt
@@ -7,13 +7,14 @@ import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.pandulapeter.beagle.Beagle
 import com.pandulapeter.beagle.BeagleCore
 import com.pandulapeter.beagle.R
-import com.pandulapeter.beagle.common.configuration.Insets
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.common.listeners.UpdateListener
 import com.pandulapeter.beagle.core.util.extension.applyTheme
 import com.pandulapeter.beagle.core.view.InternalDebugMenuView
@@ -104,20 +105,17 @@ internal class DebugMenuBottomSheet : BottomSheetDialogFragment(), UpdateListene
             behavior.peekHeight = height / 2
             post { updateApplyResetBlockPosition() }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                Beagle.currentActivity?.window?.decorView?.rootWindowInsets?.let {
-                    val inputInsets = Insets(
-                        left = it.systemWindowInsetLeft,
-                        top = it.systemWindowInsetTop,
-                        right = it.systemWindowInsetRight,
-                        bottom = it.systemWindowInsetBottom
-                    )
-                    (BeagleCore.implementation.appearance.applyInsets?.invoke(inputInsets) ?: inputInsets).also { outputInsets ->
-                        (view as? InternalDebugMenuView)?.applyInsets(
-                            outputInsets.left,
-                            0,
-                            outputInsets.right,
-                            outputInsets.bottom + outputInsets.top //TODO: Temporary fix for a landscape issue
-                        )
+                Beagle.currentActivity?.window?.decorView?.let { view ->
+                    view.rootWindowInsets?.let { insets ->
+                        val inputInsets = WindowInsetsCompat.toWindowInsetsCompat(insets, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                        (BeagleCore.implementation.appearance.applyInsets?.invoke(inputInsets) ?: inputInsets).also { outputInsets ->
+                            (view as? InternalDebugMenuView)?.applyInsets(
+                                outputInsets.left,
+                                0,
+                                outputInsets.right,
+                                outputInsets.bottom + outputInsets.top //TODO: Temporary fix for a landscape issue
+                            )
+                        }
                     }
                 }
             }

--- a/ui-dialog/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuDialog.kt
+++ b/ui-dialog/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuDialog.kt
@@ -7,9 +7,10 @@ import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.FragmentManager
 import com.pandulapeter.beagle.BeagleCore
-import com.pandulapeter.beagle.common.configuration.Insets
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.core.util.extension.applyTheme
 import com.pandulapeter.beagle.core.view.InternalDebugMenuView
 import kotlin.math.roundToInt
@@ -31,21 +32,26 @@ internal class DebugMenuDialog : AppCompatDialogFragment() {
             BeagleCore.implementation.currentActivity?.run {
                 windowManager.defaultDisplay.getMetrics(displayMetrics)
                 val output = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    window.decorView.rootWindowInsets?.let {
-                        BeagleCore.implementation.appearance.applyInsets?.invoke(
-                            Insets(
-                                left = it.systemWindowInsetLeft,
-                                top = it.systemWindowInsetTop,
-                                right = it.systemWindowInsetRight,
-                                bottom = it.systemWindowInsetBottom
+                    window?.decorView?.let { view ->
+                        view.rootWindowInsets?.let { insets ->
+                            BeagleCore.implementation.appearance.applyInsets?.invoke(
+                                WindowInsetsCompat.toWindowInsetsCompat(insets, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
                             )
-                        )
+                        }
                     }
                 } else null
                 val verticalInsets = output?.let { it.top + it.bottom }
-                    ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) window.decorView.rootWindowInsets?.let { it.systemWindowInsetTop + it.systemWindowInsetBottom } ?: 0 else 0
+                    ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                        window.decorView.rootWindowInsets?.let {
+                            val insets = WindowInsetsCompat.toWindowInsetsCompat(it, window.decorView).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                            insets.top + insets.bottom
+                        } ?: 0 else 0
                 val horizontalInsets = output?.let { it.left + it.right }
-                    ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) window.decorView.rootWindowInsets?.let { it.systemWindowInsetLeft + it.systemWindowInsetRight } ?: 0 else 0
+                    ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                        window.decorView.rootWindowInsets?.let {
+                            val insets = WindowInsetsCompat.toWindowInsetsCompat(it, window.decorView).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
+                            insets.left + insets.right
+                        } ?: 0 else 0
                 setLayout(
                     ((displayMetrics.widthPixels - horizontalInsets) * DIALOG_WIDTH_RATIO).roundToInt(),
                     ((displayMetrics.heightPixels - verticalInsets) * DIALOG_HEIGHT_RATIO).roundToInt()

--- a/ui-drawer/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuDrawerLayout.kt
+++ b/ui-drawer/src/main/java/com/pandulapeter/beagle/logCrash/implementation/DebugMenuDrawerLayout.kt
@@ -10,10 +10,11 @@ import android.view.ViewConfiguration
 import android.view.WindowInsets
 import androidx.annotation.RequiresApi
 import androidx.core.view.GravityCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import com.pandulapeter.beagle.BeagleCore
 import com.pandulapeter.beagle.R
-import com.pandulapeter.beagle.common.configuration.Insets
+import com.pandulapeter.beagle.common.configuration.getBeagleInsets
 import com.pandulapeter.beagle.core.view.InternalDebugMenuView
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -84,7 +85,7 @@ internal class DebugMenuDrawerLayout(
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
                 debugMenuView.run {
-                    setOnApplyWindowInsetsListener { _, insets -> insets.also(::updateInsets) }
+                    setOnApplyWindowInsetsListener { view, insets -> insets.also { updateInsets(it, view) } }
                     requestApplyInsets()
                 }
             }
@@ -92,13 +93,8 @@ internal class DebugMenuDrawerLayout(
     }
 
     @RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
-    private fun updateInsets(insets: WindowInsets) {
-        val input = Insets(
-            left = insets.systemWindowInsetLeft,
-            top = insets.systemWindowInsetTop,
-            right = insets.systemWindowInsetRight,
-            bottom = insets.systemWindowInsetBottom
-        )
+    private fun updateInsets(insets: WindowInsets, view: View) {
+        val input = WindowInsetsCompat.toWindowInsetsCompat(insets, view).getBeagleInsets(WindowInsetsCompat.Type.systemBars())
         val output = (BeagleCore.implementation.appearance.applyInsets?.invoke(input) ?: input)
         debugMenuView.applyInsets(output.left, output.top, output.right, output.bottom)
     }


### PR DESCRIPTION
## What
• Attempts to fix #37 
• Use [WindowInsetsCompat](https://developer.android.com/reference/androidx/core/view/WindowInsetsCompat) to get insets based on type instead of deprecated fields on insets.
• Use [WindowCompat](https://developer.android.com/reference/androidx/core/view/WindowCompat) in `DebugMenuBottomSheeet` to handle system windows over decor, replacing deprecated flags. Not sure if this is required as there was no visual changes in my tests with or without this call. But this PR doesn't change the implementation so kept it as it is.
• Tests by running all 4 variant apps on Pixel 5 running android 11 (sdk 31).

## Resources
[Developer guide](https://developer.android.com/training/gestures/edge-to-edge?hl=fr) and [youtube video](https://www.youtube.com/watch?v=acC7SR1EXsI).