### PR TITLE
Add required flag for pending intents to screen recording notification

### DIFF
--- a/internal-core/src/main/java/com/pandulapeter/beagle/core/util/ScreenCaptureService.kt
+++ b/internal-core/src/main/java/com/pandulapeter/beagle/core/util/ScreenCaptureService.kt
@@ -1,6 +1,8 @@
 package com.pandulapeter.beagle.core.util
 
 import android.app.*
+import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.hardware.display.DisplayManager
@@ -181,12 +183,20 @@ internal class ScreenCaptureService : Service() {
                 .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .apply {
                     if (isForVideo) {
+                        val intentFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                            FLAG_IMMUTABLE
+                        } else {
+                            0
+                        }
                         setContentIntent(
                             PendingIntent.getService(
                                 this@ScreenCaptureService,
                                 0,
-                                Intent(this@ScreenCaptureService, ScreenCaptureService::class.java).setAction(ACTION_DONE),
-                                0
+                                Intent(
+                                    this@ScreenCaptureService,
+                                    ScreenCaptureService::class.java
+                                ).setAction(ACTION_DONE),
+                                intentFlag
                             )
                         )
                         setStyle(NotificationCompat.BigTextStyle().bigText(text(BeagleCore.implementation.appearance.screenCaptureTexts.inProgressNotificationContent)))


### PR DESCRIPTION
A fix for #103 by adding the required flag if the SDK is 31 or above, otherwise it will provide the previous used flag.